### PR TITLE
CXX_STD = CXX17

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,1 @@
+CXX_STD = CXX17

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,1 +1,2 @@
 PKG_LIBS = -lopenblas -llapack -lblas -fopenmp
+CXX_STD = CXX17


### PR DESCRIPTION
this should fix the following error which @deepcharles was observing using R-4.2.0
```
(base) hoct2726@dinf-thock-02i:~/R/dust[fix-install]$ cd src/
(base) hoct2726@dinf-thock-02i:~/R/dust/src[fix-install]$ rm MD_B_Indices.o
(base) hoct2726@dinf-thock-02i:~/R/dust/src[fix-install]$ R CMD INSTALL ..
* installing to library ‘/home/local/USHERBROOKE/hoct2726/lib/R/library’
* installing *source* package ‘dust’ ...
** this is package ‘dust’ version ‘0.3.0’
** using staged installation
** libs
using C++ compiler: ‘g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0’
using C++17
g++ -std=gnu++17 -I"/home/local/USHERBROOKE/hoct2726/lib/R/include" -DNDEBUG  -I'/home/local/USHERBROOKE/hoct2726/lib/R/library/Rcpp/include' -I'/home/local/USHERBROOKE/hoct2726/lib/R/library/RcppArmadillo/include' -I/usr/local/include    -fpic  -g -O2   -c MD_B_Indices.cpp -o MD_B_Indices.o
g++ -std=gnu++17 -shared -L/home/local/USHERBROOKE/hoct2726/lib/R/lib -L/usr/local/lib -o dust.so 1D_A1_GaussModel.o 1D_A2_PoissonModel.o 1D_A3_ExpModel.o 1D_A4_GeomModel.o 1D_A5_BernModel.o 1D_A6_BinomModel.o 1D_A7_NegbinModel.o 1D_A8_VarianceModel.o 1D_A_DUST.o 1D_B_Indices.o 2D_B_Indices2.o 2D_DUSTmeanVar.o 2D_DUSTreg.o MD_A1_GaussModel.o MD_A2_PoissonModel.o MD_A3_ExpModel.o MD_A4_GeomModel.o MD_A5_BernModel.o MD_A6_BinomModel.o MD_A7_NegbinModel.o MD_A8_VarianceModel.o MD_A_DUST.o MD_B_Indices.o RcppExports.o _ModuleAssembly_1D.o _ModuleAssembly_2D.o _ModuleAssembly_MD.o flat_Gauss_MD.o flat_OP_1D_gauss.o flat_OP_MD_gauss.o flat_dust_1D_gauss.o preProcessing.o testRCPP.o utils.o -L/home/local/USHERBROOKE/hoct2726/lib/R/lib -lR
installing to /home/local/USHERBROOKE/hoct2726/lib/R/library/00LOCK-dust/00new/dust/libs
** R
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
*** copying figures
** building package indices
** testing if installed package can be loaded from temporary location
** checking absolute paths in shared objects and dynamic libraries
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (dust)
```
Above the C++ compiler flag `-std=gnu++17` means to use C++ 17 standard.
Below I changed the flag to `-std=gnu++14` and we get the same error as on Charles' computer. 
```
(base) hoct2726@dinf-thock-02i:~/R/dust/src[fix-install]$ g++ -std=gnu++14 -I"/home/local/USHERBROOKE/hoct2726/lib/R/include" -DNDEBUG  -I'/home/local/USHERBROOKE/hoct2726/lib/R/library/Rcpp/include' -I'/home/local/USHERBROOKE/hoct2726/lib/R/library/RcppArmadillo/include' -I/usr/local/include    -fpic  -g -O2   -c MD_B_Indices.cpp -o MD_B_Indices.o
MD_B_Indices.cpp: In member function ‘virtual std::vector<unsigned int> DeterministicIndices_MD::get_constraints_l()’:
MD_B_Indices.cpp:101:21: error: missing template arguments before ‘(’ token
  101 |   return std::vector(begin_l, current);
      |                     ^
MD_B_Indices.cpp: In member function ‘virtual std::vector<unsigned int> DeterministicIndices_MD::get_constraints_r()’:
MD_B_Indices.cpp:111:21: error: missing template arguments before ‘(’ token
  111 |   return std::vector(current + 1, end_r);
      |                     ^
MD_B_Indices.cpp: In constructor ‘RandomIndices_MD::RandomIndices_MD(const unsigned int&, const unsigned int&)’:
MD_B_Indices.cpp:126:40: error: missing template arguments before ‘(’ token
  126 |   , dist(std::uniform_real_distribution(0., 1.))
      |                                        ^
```
The proposed fix adds a line to Makevars to tell R to use the C++ 17 compiler flag.
@vrunge please review.